### PR TITLE
os.linux: remove unnecessary calls to getQuarkRelative

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IPIEntryHandler.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/kernel/handlers/IPIEntryHandler.java
@@ -54,12 +54,12 @@ public class IPIEntryHandler extends KernelEventHandler {
         ss.modifyAttribute(timestamp, value, quark);
 
         /* Change the status of the running process to interrupted */
-        quark = ss.getQuarkRelativeAndAdd(KernelEventHandlerUtils.getCurrentThreadNode(cpu, ss));
+        quark = KernelEventHandlerUtils.getCurrentThreadNode(cpu, ss);
         value = StateValues.PROCESS_STATUS_INTERRUPTED_VALUE;
         ss.modifyAttribute(timestamp, value, quark);
 
         /* Change the status of the CPU to interrupted */
-        quark = ss.getQuarkRelativeAndAdd(KernelEventHandlerUtils.getCurrentCPUNode(cpu, ss));
+        quark = KernelEventHandlerUtils.getCurrentCPUNode(cpu, ss);
         value = StateValues.CPU_STATUS_IRQ_VALUE;
         ss.modifyAttribute(timestamp, value, quark);
     }


### PR DESCRIPTION
When the Status attribute was removed, some calls to
getAttributeQuarkRelative were not removed and that causes exceptions in
some cases.

Change-Id: Ib217c44b51eae713101aafb6d3025475fcf2ed99
Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>
Reviewed-on: https://git.eclipse.org/r/81381
Reviewed-by: Matthew Khouzam matthew.khouzam@ericsson.com
Reviewed-by: Hudson CI
