### PR TITLE
Fix latency table columns

### DIFF
--- a/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/latency/SystemCallLatencyAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.os.linux.core/src/org/eclipse/tracecompass/internal/analysis/os/linux/core/latency/SystemCallLatencyAnalysis.java
@@ -13,12 +13,11 @@ import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.text.DecimalFormat;
-import java.text.Format;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -32,14 +31,11 @@ import org.eclipse.tracecompass.analysis.os.linux.core.trace.IKernelTrace;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.AbstractSegmentStoreAnalysisEventBasedModule;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
-import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.analysis.IAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
-import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestampFormat;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 /**
@@ -54,9 +50,6 @@ public class SystemCallLatencyAnalysis extends AbstractSegmentStoreAnalysisEvent
     public static final String ID = "org.eclipse.tracecompass.analysis.os.linux.latency.syscall"; //$NON-NLS-1$
 
     private static final String DATA_FILENAME = "latency-analysis.dat"; //$NON-NLS-1$
-
-    private static final Collection<ISegmentAspect> BASE_ASPECTS =
-            ImmutableList.of(StartAspect.INSTANCE, EndAspect.INSTANCE, DurationAspect.INSTANCE, SyscallNameAspect.INSTANCE);
 
     @Override
     public String getId() {
@@ -78,7 +71,10 @@ public class SystemCallLatencyAnalysis extends AbstractSegmentStoreAnalysisEvent
 
     @Override
     public Iterable<ISegmentAspect> getSegmentAspects() {
-        return BASE_ASPECTS;
+        List<ISegmentAspect> aspects = new ArrayList<>();
+        aspects.addAll(BASED_SEGMENT_ASPECTS);
+        aspects.add(SyscallNameAspect.INSTANCE);
+        return aspects;
     }
 
     @Override
@@ -204,88 +200,6 @@ public class SystemCallLatencyAnalysis extends AbstractSegmentStoreAnalysisEvent
                 return ((SystemCall) segment).getName();
             }
             return EMPTY_STRING;
-        }
-    }
-
-    private static final class StartAspect implements ISegmentAspect {
-        public static final ISegmentAspect INSTANCE = new StartAspect();
-
-        private StartAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("Start Time");
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("Start Time");
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_START_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getStart());
-        }
-    }
-
-    private static final class EndAspect implements ISegmentAspect {
-        public static final ISegmentAspect INSTANCE = new EndAspect();
-
-        private EndAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("End Time");
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("End Time");
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_END_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getEnd());
-        }
-    }
-
-    private static final Format FORMATTER = new DecimalFormat("###,###.##");
-    private static final class DurationAspect implements ISegmentAspect {
-        public static final ISegmentAspect INSTANCE = new DurationAspect();
-
-        private DurationAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("Duration");
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("Duration");
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_LENGTH_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return FORMATTER.format(segment.getLength());
         }
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/analysis/timing/core/segmentstore/ISegmentStoreProvider.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/analysis/timing/core/segmentstore/ISegmentStoreProvider.java
@@ -9,10 +9,21 @@
 
 package org.eclipse.tracecompass.analysis.timing.core.segmentstore;
 
+import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
+
+import java.text.DecimalFormat;
+import java.text.Format;
+import java.util.Comparator;
+import java.util.List;
+
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
+import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
+import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestampFormat;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Segment store provider. Useful to populate views.
@@ -52,7 +63,8 @@ public interface ISegmentStoreProvider {
      *
      * @return Results from the analysis in a ISegmentStore
      */
-    @Nullable ISegmentStore<ISegment> getSegmentStore();
+    @Nullable
+    ISegmentStore<ISegment> getSegmentStore();
 
     /**
      * Get the ID of the segment store provider
@@ -62,4 +74,111 @@ public interface ISegmentStoreProvider {
      */
     String getProviderId();
 
+    /**
+     * Base segments aspects
+     * @since 2.0
+     */
+    static List<ISegmentAspect> BASED_SEGMENT_ASPECTS = ImmutableList.of(StartAspect.INSTANCE, EndAspect.INSTANCE,
+            DurationAspect.INSTANCE);
+    /**
+     * Start aspects
+     *
+     * @author Jean-Christian Kouame
+     * @since 2.0
+     *
+     */
+    final class StartAspect implements ISegmentAspect {
+        public static final ISegmentAspect INSTANCE = new StartAspect();
+
+        private StartAspect() {
+        }
+
+        @Override
+        public String getHelpText() {
+            return checkNotNull("Start Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getName() {
+            return checkNotNull("Start Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public @Nullable Comparator<?> getComparator() {
+            return SegmentComparators.INTERVAL_START_COMPARATOR;
+        }
+
+        @Override
+        public @Nullable String resolve(ISegment segment) {
+            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getStart());
+        }
+    }
+
+    /**
+     * End aspects
+     *
+     * @author Jean-Christian Kouame
+     * @since 2.0
+     *
+     */
+    final class EndAspect implements ISegmentAspect {
+        public static final ISegmentAspect INSTANCE = new EndAspect();
+
+        private EndAspect() {
+        }
+
+        @Override
+        public String getHelpText() {
+            return checkNotNull("End Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getName() {
+            return checkNotNull("End Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public @Nullable Comparator<?> getComparator() {
+            return SegmentComparators.INTERVAL_END_COMPARATOR;
+        }
+
+        @Override
+        public @Nullable String resolve(ISegment segment) {
+            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getEnd());
+        }
+    }
+
+    /**
+     * Duration aspects
+     *
+     * @author Jean-Christian Kouame
+     * @since 2.0
+     */
+    final class DurationAspect implements ISegmentAspect {
+        public static final ISegmentAspect INSTANCE = new DurationAspect();
+        private static final Format DECIMAL_FORMAT = new DecimalFormat("###,###.##"); //$NON-NLS-1$
+
+        private DurationAspect() {
+        }
+
+        @Override
+        public String getHelpText() {
+            return checkNotNull("Duration"); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getName() {
+            return checkNotNull("Duration"); //$NON-NLS-1$
+        }
+
+        @Override
+        public @Nullable Comparator<?> getComparator() {
+            return SegmentComparators.INTERVAL_LENGTH_COMPARATOR;
+        }
+
+        @Override
+        public @Nullable String resolve(ISegment segment) {
+            return DECIMAL_FORMAT.format(segment.getLength());
+        }
+    }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/inandout/InAndOutAnalysis.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.core/src/org/eclipse/tracecompass/internal/analysis/timing/core/inandout/InAndOutAnalysis.java
@@ -4,8 +4,6 @@ import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.text.DecimalFormat;
-import java.text.Format;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -21,19 +19,15 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.AbstractSegmentStoreAnalysisEventBasedModule;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
-import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.event.ITmfEvent;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 import org.eclipse.tracecompass.tmf.core.timestamp.ITmfTimestamp;
-import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestampFormat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 public class InAndOutAnalysis extends AbstractSegmentStoreAnalysisEventBasedModule {
 
     private static final Map<String, IInAndOutHandler> HANDLERS = new HashMap<>();
-    private static final Format DECIMAL_FORMAT = new DecimalFormat("###,###.##"); //$NON-NLS-1$
 
     static {
         HANDLERS.put("i2c_write", (ITmfEvent event, Map<String, ITmfTimestamp> currentStack, Collection<@NonNull ISegment> store, Collection<@NonNull ISegment> markers) -> currentStack.put("I2C_WRITE", event.getTimestamp())); //$NON-NLS-1$ //$NON-NLS-2$
@@ -68,7 +62,7 @@ public class InAndOutAnalysis extends AbstractSegmentStoreAnalysisEventBasedModu
     public @NonNull Iterable<@NonNull ISegmentAspect> getSegmentAspects() {
         List<@NonNull ISegmentAspect> aspects = new ArrayList<>();
         Iterables.addAll(aspects, super.getSegmentAspects());
-        aspects.addAll(ImmutableList.of(StartAspect.INSTANCE, EndAspect.INSTANCE, DurationAspect.INSTANCE));
+        aspects.addAll(BASED_SEGMENT_ASPECTS);
         aspects.add(new ISegmentAspect() {
 
             @Override
@@ -163,86 +157,5 @@ public class InAndOutAnalysis extends AbstractSegmentStoreAnalysisEventBasedModu
 
     public Collection<@NonNull ISegment> getMarkers() {
         return fExposedMarker;
-    }
-
-    private static final class StartAspect implements ISegmentAspect {
-        public static final @NonNull ISegmentAspect INSTANCE = new StartAspect();
-
-        private StartAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("Start Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("Start Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_START_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getStart());
-        }
-    }
-
-    private static final class EndAspect implements ISegmentAspect {
-        public static final @NonNull ISegmentAspect INSTANCE = new EndAspect();
-
-        private EndAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("End Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("End Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_END_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getEnd());
-        }
-    }
-
-    private static final class DurationAspect implements ISegmentAspect {
-        public static final @NonNull ISegmentAspect INSTANCE = new DurationAspect();
-
-        private DurationAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("Duration"); //$NON-NLS-1$
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("Duration"); //$NON-NLS-1$
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_LENGTH_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return DECIMAL_FORMAT.format(segment.getLength());
-        }
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/internal/analysis/timing/ui/callgraph/CallGraphAnalysisUI.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/internal/analysis/timing/ui/callgraph/CallGraphAnalysisUI.java
@@ -9,11 +9,21 @@
 
 package org.eclipse.tracecompass.internal.analysis.timing.ui.callgraph;
 
-import java.util.Collections;
+import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
+
+import java.text.DecimalFormat;
+import java.text.Format;
+import java.util.Comparator;
 
 import org.eclipse.jdt.annotation.NonNull;
+import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.internal.analysis.timing.core.callgraph.CallGraphAnalysis;
+import org.eclipse.tracecompass.segmentstore.core.ISegment;
+import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
+import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestampFormat;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * CallGraph Analysis with aspects
@@ -26,6 +36,7 @@ public class CallGraphAnalysisUI extends CallGraphAnalysis {
      * ID
      */
     public static final @NonNull String ID = "org.eclipse.tracecompass.internal.analysis.timing.ui.callgraph.callgraphanalysis"; //$NON-NLS-1$
+    private static final Format DECIMAL_FORMAT = new DecimalFormat("###,###.##"); //$NON-NLS-1$
 
     /**
      * Default constructor
@@ -36,6 +47,88 @@ public class CallGraphAnalysisUI extends CallGraphAnalysis {
 
     @Override
     public @NonNull Iterable<@NonNull ISegmentAspect> getSegmentAspects() {
-        return Collections.singletonList(SymbolAspect.SYMBOL_ASPECT);
+        return ImmutableList.of(StartAspect.INSTANCE, EndAspect.INSTANCE,
+                DurationAspect.INSTANCE, SymbolAspect.SYMBOL_ASPECT);
+    }
+
+    private static final class StartAspect implements ISegmentAspect {
+        public static final @NonNull ISegmentAspect INSTANCE = new StartAspect();
+
+        private StartAspect() {
+        }
+
+        @Override
+        public String getHelpText() {
+            return checkNotNull("Start Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getName() {
+            return checkNotNull("Start Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public @Nullable Comparator<?> getComparator() {
+            return SegmentComparators.INTERVAL_START_COMPARATOR;
+        }
+
+        @Override
+        public @Nullable String resolve(ISegment segment) {
+            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getStart());
+        }
+    }
+
+    private static final class EndAspect implements ISegmentAspect {
+        public static final @NonNull ISegmentAspect INSTANCE = new EndAspect();
+
+        private EndAspect() {
+        }
+
+        @Override
+        public String getHelpText() {
+            return checkNotNull("End Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getName() {
+            return checkNotNull("End Time"); //$NON-NLS-1$
+        }
+
+        @Override
+        public @Nullable Comparator<?> getComparator() {
+            return SegmentComparators.INTERVAL_END_COMPARATOR;
+        }
+
+        @Override
+        public @Nullable String resolve(ISegment segment) {
+            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getEnd());
+        }
+    }
+
+    private static final class DurationAspect implements ISegmentAspect {
+        public static final @NonNull ISegmentAspect INSTANCE = new DurationAspect();
+
+        private DurationAspect() {
+        }
+
+        @Override
+        public String getHelpText() {
+            return checkNotNull("Duration"); //$NON-NLS-1$
+        }
+
+        @Override
+        public String getName() {
+            return checkNotNull("Duration"); //$NON-NLS-1$
+        }
+
+        @Override
+        public @Nullable Comparator<?> getComparator() {
+            return SegmentComparators.INTERVAL_LENGTH_COMPARATOR;
+        }
+
+        @Override
+        public @Nullable String resolve(ISegment segment) {
+            return DECIMAL_FORMAT.format(segment.getLength());
+        }
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/internal/analysis/timing/ui/callgraph/CallGraphAnalysisUI.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/internal/analysis/timing/ui/callgraph/CallGraphAnalysisUI.java
@@ -9,21 +9,14 @@
 
 package org.eclipse.tracecompass.internal.analysis.timing.ui.callgraph;
 
-import static org.eclipse.tracecompass.common.core.NonNullUtils.checkNotNull;
-
-import java.text.DecimalFormat;
-import java.text.Format;
-import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNull;
-import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.internal.analysis.timing.core.callgraph.CallGraphAnalysis;
-import org.eclipse.tracecompass.segmentstore.core.ISegment;
-import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
-import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestampFormat;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 /**
  * CallGraph Analysis with aspects
@@ -36,7 +29,6 @@ public class CallGraphAnalysisUI extends CallGraphAnalysis {
      * ID
      */
     public static final @NonNull String ID = "org.eclipse.tracecompass.internal.analysis.timing.ui.callgraph.callgraphanalysis"; //$NON-NLS-1$
-    private static final Format DECIMAL_FORMAT = new DecimalFormat("###,###.##"); //$NON-NLS-1$
 
     /**
      * Default constructor
@@ -47,88 +39,9 @@ public class CallGraphAnalysisUI extends CallGraphAnalysis {
 
     @Override
     public @NonNull Iterable<@NonNull ISegmentAspect> getSegmentAspects() {
-        return ImmutableList.of(StartAspect.INSTANCE, EndAspect.INSTANCE,
-                DurationAspect.INSTANCE, SymbolAspect.SYMBOL_ASPECT);
-    }
-
-    private static final class StartAspect implements ISegmentAspect {
-        public static final @NonNull ISegmentAspect INSTANCE = new StartAspect();
-
-        private StartAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("Start Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("Start Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_START_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getStart());
-        }
-    }
-
-    private static final class EndAspect implements ISegmentAspect {
-        public static final @NonNull ISegmentAspect INSTANCE = new EndAspect();
-
-        private EndAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("End Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("End Time"); //$NON-NLS-1$
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_END_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getEnd());
-        }
-    }
-
-    private static final class DurationAspect implements ISegmentAspect {
-        public static final @NonNull ISegmentAspect INSTANCE = new DurationAspect();
-
-        private DurationAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull("Duration"); //$NON-NLS-1$
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull("Duration"); //$NON-NLS-1$
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_LENGTH_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return DECIMAL_FORMAT.format(segment.getLength());
-        }
+        List<@NonNull ISegmentAspect> aspects = new ArrayList<>();
+        Iterables.addAll(aspects, BASED_SEGMENT_ASPECTS);
+        aspects.add(SymbolAspect.SYMBOL_ASPECT);
+        return aspects;
     }
 }

--- a/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/internal/analysis/timing/ui/callgraph/CallGraphDensityView.java
+++ b/analysis/org.eclipse.tracecompass.analysis.timing.ui/src/org/eclipse/tracecompass/internal/analysis/timing/ui/callgraph/CallGraphDensityView.java
@@ -13,7 +13,6 @@ import org.eclipse.jdt.annotation.NonNull;
 import org.eclipse.jface.viewers.TableViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Table;
 import org.eclipse.tracecompass.analysis.timing.ui.views.segmentstore.density.AbstractSegmentStoreDensityView;
 import org.eclipse.tracecompass.analysis.timing.ui.views.segmentstore.density.AbstractSegmentStoreDensityViewer;
 import org.eclipse.tracecompass.analysis.timing.ui.views.segmentstore.table.AbstractSegmentStoreTableViewer;
@@ -38,14 +37,7 @@ public class CallGraphDensityView extends AbstractSegmentStoreDensityView {
 
     @Override
     protected AbstractSegmentStoreTableViewer createSegmentStoreTableViewer(Composite parent) {
-        return new CallGraphTableViewer(new TableViewer(parent, SWT.FULL_SELECTION | SWT.VIRTUAL)) {
-            @Override
-            protected void createProviderColumns() {
-                super.createProviderColumns();
-                Table t = (Table) getControl();
-                t.setColumnOrder(new int[] { 2, 3, 0, 1 });
-            }
-        };
+        return new CallGraphTableViewer(new TableViewer(parent, SWT.FULL_SELECTION | SWT.VIRTUAL));
     }
 
     @Override

--- a/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core/src/org/eclipse/tracecompass/internal/tmf/analysis/xml/core/pattern/stateprovider/XmlPatternAnalysis.java
+++ b/tmf/org.eclipse.tracecompass.tmf.analysis.xml.core/src/org/eclipse/tracecompass/internal/tmf/analysis/xml/core/pattern/stateprovider/XmlPatternAnalysis.java
@@ -27,20 +27,17 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.IAnalysisProgressListener;
 import org.eclipse.tracecompass.analysis.timing.core.segmentstore.ISegmentStoreProvider;
 import org.eclipse.tracecompass.analysis.timing.ui.views.segmentstore.SubSecondTimeWithUnitFormat;
-import org.eclipse.tracecompass.internal.analysis.timing.ui.views.segmentstore.table.Messages;
 import org.eclipse.tracecompass.internal.tmf.analysis.xml.core.model.TmfXmlPatternSegmentBuilder;
 import org.eclipse.tracecompass.internal.tmf.analysis.xml.core.segment.TmfXmlPatternCompositeSegment;
 import org.eclipse.tracecompass.internal.tmf.analysis.xml.core.segment.TmfXmlPatternSegment;
 import org.eclipse.tracecompass.internal.tmf.analysis.xml.core.stateprovider.TmfXmlStrings;
 import org.eclipse.tracecompass.segmentstore.core.ISegment;
 import org.eclipse.tracecompass.segmentstore.core.ISegmentStore;
-import org.eclipse.tracecompass.segmentstore.core.SegmentComparators;
 import org.eclipse.tracecompass.statesystem.core.ITmfStateSystem;
 import org.eclipse.tracecompass.tmf.core.analysis.TmfAbstractAnalysisModule;
 import org.eclipse.tracecompass.tmf.core.exceptions.TmfAnalysisException;
 import org.eclipse.tracecompass.tmf.core.segment.ISegmentAspect;
 import org.eclipse.tracecompass.tmf.core.statesystem.ITmfAnalysisModuleWithStateSystems;
-import org.eclipse.tracecompass.tmf.core.timestamp.TmfTimestampFormat;
 import org.eclipse.tracecompass.tmf.core.trace.ITmfTrace;
 import org.eclipse.tracecompass.tmf.core.trace.TmfTraceManager;
 
@@ -268,7 +265,7 @@ public class XmlPatternAnalysis extends TmfAbstractAnalysisModule implements ITm
     private @NonNull
     static Iterable<ISegmentAspect> buildChainAspects(XmlPatternStateProvider provider, @NonNull ImmutableList<ISegmentAspect> immutableList) {
         @NonNull List<ISegmentAspect> aspects = new ArrayList<>();
-        aspects.addAll(BASED_TABLE_ASPECTS);
+        aspects.addAll(BASED_SEGMENT_ASPECTS);
         aspects.addAll(immutableList);
         final String prefix = "Time to "; //$NON-NLS-1$
         for (int i = 0; i < provider.getChainStates().size(); i++) {
@@ -338,11 +335,11 @@ public class XmlPatternAnalysis extends TmfAbstractAnalysisModule implements ITm
 
         @Override
         public String getHelpText() {
-            return checkNotNull("Name");
+            return checkNotNull("Name"); //$NON-NLS-1$
         }
         @Override
         public String getName() {
-            return checkNotNull("Name");
+            return checkNotNull("Name"); //$NON-NLS-1$
         }
         @Override
         public @Nullable Comparator<?> getComparator() {
@@ -368,11 +365,11 @@ public class XmlPatternAnalysis extends TmfAbstractAnalysisModule implements ITm
 
         @Override
         public String getHelpText() {
-            return checkNotNull("Content");
+            return checkNotNull("Content"); //$NON-NLS-1$
         }
         @Override
         public String getName() {
-            return checkNotNull("Content");
+            return checkNotNull("Content"); //$NON-NLS-1$
         }
         @Override
         public @Nullable Comparator<?> getComparator() {
@@ -388,89 +385,6 @@ public class XmlPatternAnalysis extends TmfAbstractAnalysisModule implements ITm
                 return String.join(", ", values); //$NON-NLS-1$
             }
             return EMPTY_STRING;
-        }
-    }
-
-    private static List<ISegmentAspect> BASED_TABLE_ASPECTS = ImmutableList.of(StartAspect.INSTANCE, EndAspect.INSTANCE,
-            DurationAspect.INSTANCE);
-    private static final class StartAspect implements ISegmentAspect {
-        public static final ISegmentAspect INSTANCE = new StartAspect();
-
-        private StartAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull(Messages.SegmentStoreTableViewer_startTime);
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull(Messages.SegmentStoreTableViewer_startTime);
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_START_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getStart());
-        }
-    }
-
-    private static final class EndAspect implements ISegmentAspect {
-        public static final ISegmentAspect INSTANCE = new EndAspect();
-
-        private EndAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull(Messages.SegmentStoreTableViewer_endTime);
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull(Messages.SegmentStoreTableViewer_endTime);
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_END_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return TmfTimestampFormat.getDefaulTimeFormat().format(segment.getEnd());
-        }
-    }
-
-    private static final class DurationAspect implements ISegmentAspect {
-        public static final ISegmentAspect INSTANCE = new DurationAspect();
-
-        private DurationAspect() {
-        }
-
-        @Override
-        public String getHelpText() {
-            return checkNotNull(Messages.SegmentStoreTableViewer_duration);
-        }
-
-        @Override
-        public String getName() {
-            return checkNotNull(Messages.SegmentStoreTableViewer_duration);
-        }
-
-        @Override
-        public @Nullable Comparator<?> getComparator() {
-            return SegmentComparators.INTERVAL_LENGTH_COMPARATOR;
-        }
-
-        @Override
-        public @Nullable String resolve(ISegment segment) {
-            return DECIMAL_FORMAT.format(segment.getLength());
         }
     }
 }


### PR DESCRIPTION
Those issues was introduce with the segment filter prototype commit. The
analysis needs to know all the segment aspects so it could rebuild the
filter for any segment aspects. This is a quick temporary solution. The
definitive solution should add some base segment aspects in the Abstract
analysis or in the segment provider interface.

Change-Id: Ie9ad414475d9c84dfa1ae2d82816da1d62ac0440
Signed-off-by: Jean-Christian Kouame jean-christian.kouame@ericsson.com
